### PR TITLE
Add CSP middleware to allow Swagger UI CDN resources

### DIFF
--- a/backend/reptrack_backend/settings/base.py
+++ b/backend/reptrack_backend/settings/base.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'reptrack_backend.middleware.BlockSuspiciousParamsMiddleware',
+    'reptrack_backend.middleware.APIDocsCSPMiddleware',
     'reptrack_backend.middleware.CacheControlMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
- Create APIDocsCSPMiddleware to relax CSP for /api/docs, /api/redoc, /api/schema
- Allow cdn.jsdelivr.net for scripts, styles, images, and fonts
- Position middleware early in chain to override restrictive CSP from nginx/proxy
- Fixes CSP blocking issues preventing API documentation from loading in production